### PR TITLE
fixed useActionData overriding error clearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-hook-form",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-hook-form",
-      "version": "1.1.0",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@hookform/resolvers": "^3.1.0",

--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { SubmitFunction, useActionData, useSubmit } from "@remix-run/react";
 import {
   SubmitErrorHandler,
@@ -35,9 +35,11 @@ export const useRemixForm = <T extends FieldValues>({
   const submit = useSubmit();
   const data = useActionData();
   const methods = useForm<T>(formProps);
+  const [formSubmitted, setFormSubmitted] = useState(false);
 
   // Submits the data to the server when form is valid
   const onSubmit = (data: T) => {
+    setFormSubmitted(true);
     submit(createFormData({ ...data, ...submitData }), {
       method: "post",
       ...submitConfig,
@@ -62,7 +64,15 @@ export const useRemixForm = <T extends FieldValues>({
     isLoading,
   } = formState;
 
-  const formErrors = mergeErrors<T>(errors, data?.errors ? data.errors : data);
+  const onMerge = () => {
+    setFormSubmitted(false);
+  };
+
+  // Will only merge data from useActionData if form was just submitted and only make
+  // formSubmitted false if data exist to useActionData to account for multiple renders
+  const formErrors = formSubmitted
+    ? mergeErrors<T>(errors, data, onMerge)
+    : errors;
 
   return {
     ...methods,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -169,9 +169,10 @@ The function recursively merges the objects and returns the resulting object.
 */
 export const mergeErrors = <T extends FieldValues>(
   frontendErrors: Partial<FieldErrorsImpl<DeepRequired<T>>>,
-  backendErrors?: Partial<FieldErrorsImpl<DeepRequired<T>>>
+  backendErrors?: Partial<FieldErrorsImpl<DeepRequired<T>>>,
+  onMerge?: () => void
 ) => {
-  if (!backendErrors) {
+  if (!backendErrors || (onMerge && Object.keys(backendErrors).length === 0)) {
     return frontendErrors;
   }
 
@@ -188,6 +189,8 @@ export const mergeErrors = <T extends FieldValues>(
       frontendErrors[key] = rightValue;
     }
   }
+
+  onMerge && onMerge();
 
   return frontendErrors;
 };


### PR DESCRIPTION
Fixes issue #12 

The reseting of submit state needs to happen in the mergeErrors function so that it will not clear the state till after the data has been added to the error.

Note: Something weird happened with the updated version. I had to spread errors in the action to get the errors to show up on the form. Did that change recently?