### PR TITLE
fix: getFormDataFromSearchParams behavior

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -69,7 +69,13 @@ export const generateFormData = (formData: FormData) => {
 
 export const getFormDataFromSearchParams = (request: Pick<Request, "url">) => {
   const searchParams = new URL(request.url).searchParams;
-  return generateFormData(searchParams as any);
+  // Parse 'formData' object from searchParams to access the nested data
+  const formDataObj = JSON.parse(searchParams.get("formData") || "{}");
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(formDataObj)) {
+    formData.append(key, value as string);
+  }
+  return generateFormData(formData);
 };
 
 export const isGet = (request: Pick<Request, "method">) =>


### PR DESCRIPTION
# Description

When making a `GET` request using `submitConfig: { method: 'get' }` (while passing `handleSubmit` to `onSubmit` property of `<Form/>`), I noticed that search params were serialized in URL like this: 

`http://localhost:3003/main/building-products?formData=%7B%22page%22%3A1%2C%22pageSize%22%3A5%2C%22userOrBuildingType%22%3A%22USER_INFO%22%7D`

Which is decoded as `'formData={"page":1,"pageSize":5,"userOrBuildingType":"USER_INFO"}'`, thus representing a formData 'object' that contains key-value pairs of searchParams.

Given this, `getFormDataFromSearchParams` in `src/utilities/index.ts` (which assumed, I think, that search params were serialized in a standard way e.g. `?a=1&b=2`) could not parse the search params properly. Consequently, `getValidatedFormData` on the same `GET` request did not work either.

I think the solution needs to be either:
1. search params in a `GET` request should be serialized in a standard way (e.g. `?page=1&pageSize=5&userOrBuildingType=USER_INFO` in my case)
2. respect the structure that the entire search params query is contained in formData 'object', and just fix internal parsing logic.

I went ahead with the latter approach. The related test are failing (which is expected), and I do not have a clear idea on how to fix these tests. 

Would love to hear your opinion on this issue :) 

Fixes # (issue)

If this is a new feature please add a description of what was added and why below:


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules