### PR TITLE
Improve `getValidatedFormData` type inference

### DIFF
--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -106,7 +106,7 @@ export const isGet = (request: Pick<Request, "method">) =>
  */
 export const getValidatedFormData = async <T extends FieldValues>(
   request: Request,
-  resolver: Resolver,
+  resolver: Resolver<T>,
 ) => {
   const data = isGet(request)
     ? getFormDataFromSearchParams(request)
@@ -124,7 +124,7 @@ export const getValidatedFormData = async <T extends FieldValues>(
  */
 export const validateFormData = async <T extends FieldValues>(
   data: any,
-  resolver: Resolver,
+  resolver: Resolver<T>,
 ) => {
   const dataToValidate =
     data instanceof FormData ? Object.fromEntries(data) : data;


### PR DESCRIPTION
# Description

Small update that should allow inferring the schema type from the resolver type when calling `getValidatedFormData` or `validateFormData`.

Partially fixes #55, though there's still an annoying upstream issue in `@hookform/resolvers` that causes `zodResolver()` to lack type inference as was [called out in this comment](https://github.com/Code-Forge-Net/remix-hook-form/issues/55#issuecomment-1824345997) (some other resolvers e.g. `yupResolver` should work fine)

Before:
```ts
const schema = z.object({ username: z.string(), password: z.string() });
const resolver = zodResolver(schema);

export const action = async ({ request }: ActionFunctionArgs) => {
  const data = await getValidatedFormData<z.infer<typeof schema>>(request, resolver);
  // ...
}
```

After:
```ts
const schema = z.object({ username: z.string(), password: z.string() });

// this annotation is still required for zod because of an upstream bug in @hookform/resolvers
const resolver: Resolver<z.infer<typeof schema>> = zodResolver(schema);

export const action = async ({ request }: ActionFunctionArgs) => {
  const data = await getValidatedFormData(request, resolver);
  // ...
}
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code