### PR TITLE
feat: added handling for date in createFormData

### DIFF
--- a/src/utilities/index.test.ts
+++ b/src/utilities/index.test.ts
@@ -1,4 +1,4 @@
-import { array, boolean, number, object, string } from "zod";
+import { array, boolean, coerce, date, number, object, string } from "zod";
 import {
   createFormData,
   generateFormData,
@@ -238,6 +238,56 @@ describe("getFormDataFromSearchParams", () => {
 });
 
 describe("validateFormData", () => {
+  it("should return an error when parsing date object without coerce", async () => {
+    const formData = createFormData({
+      date: new Date(2024, 1, 1),
+    });
+    const returnData = await validateFormData(
+      formData,
+      zodResolver(object({ date: date() })),
+    );
+    expect(returnData.errors).toStrictEqual({
+      date: {
+        message: "Expected date, received string",
+        type: "invalid_type",
+        ref: undefined,
+      },
+    });
+    expect(returnData.data).toStrictEqual(undefined);
+  });
+
+  it("should return an error when parsing date object with coerce", async () => {
+    const formData = createFormData({
+      date: new Date(2024, 1, 1),
+    });
+    const returnData = await validateFormData(
+      formData,
+      zodResolver(object({ date: coerce.date() })),
+    );
+    expect(returnData.errors).toStrictEqual({
+      date: {
+        message: "Invalid date",
+        type: "invalid_date",
+        ref: undefined,
+      },
+    });
+    expect(returnData.data).toStrictEqual(undefined);
+  });
+
+  it("should return a correct value when formatting as object", async () => {
+    const formData = createFormData({
+      date: new Date(2024, 1, 1),
+    }, false);
+    const returnData = await validateFormData(
+      formData,
+      zodResolver(object({ date: coerce.date() })),
+    );
+    expect(returnData.errors).toStrictEqual(undefined);
+    expect(returnData.data).toStrictEqual({
+      date: new Date(2024, 1, 1),
+    });
+  });
+
   it("should return an empty error object and valid data if there are no errors", async () => {
     const formData = {
       name: "John Doe",

--- a/src/utilities/index.test.ts
+++ b/src/utilities/index.test.ts
@@ -41,6 +41,12 @@ describe("createFormData", () => {
     const formData = createFormData(undefined as any);
     expect(formData).toBeTruthy();
   });
+
+  it("should handle Date data", () => {
+    const date = "2024-01-01T00:00:00.000Z";
+    const formData = createFormData({ date: new Date(date) }, false);
+    expect(formData.get("date")).toEqual(date);
+  });
 });
 
 describe("parseFormData", () => {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,9 +1,4 @@
-import type {
-  FieldValues,
-  Resolver,
-  FieldErrors,
-  DeepRequired,
-} from "react-hook-form";
+import type { FieldValues, Resolver, FieldErrors } from "react-hook-form";
 
 const tryParseJSON = (jsonString: string) => {
   try {
@@ -167,10 +162,13 @@ export const createFormData = <T extends FieldValues>(
       if (stringifyAll) {
         formData.append(key, JSON.stringify(value));
       } else {
-        formData.append(
-          key,
-          typeof value === "string" ? value : JSON.stringify(value),
-        );
+        if (typeof value === "string") {
+          formData.append(key, value);
+        } else if (value instanceof Date) {
+          formData.append(key, value.toISOString());
+        } else {
+          formData.append(key, JSON.stringify(value));
+        }
       }
     }
   });


### PR DESCRIPTION
# Description

As is, when serializing a date as JSON, it add annoying quotes in the output, which leads to error when coupling with zod.

```javascript
const date = new Date(2023, 1, 1);
console.log(JSON.stringify(date), date.toISOString(), JSON.stringify(date) === date.toISOString());
// "2023-01-31T23:00:00.000Z" 2023-01-31T23:00:00.000Z false
```

I've added a case when not "stringify" form data while using `createFormData` method to use the `toISOString()` method instead of the `JSON.stringify`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All the tests has been added inside the pr to match the issue encountered.


- [x] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules