### PR TITLE
fix: replace deprecated zod method in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ import * as zod from "zod";
 import { ActionFunctionArgs, json } from "@remix-run/node"; // or cloudflare/deno
 
 const schema = zod.object({
-  name: zod.string().nonempty(),
-  email: zod.string().email().nonempty(),
+  name: zod.string().min(1),
+  email: zod.string().email().min(1),
 });
 
 type FormData = zod.infer<typeof schema>;


### PR DESCRIPTION
# Description

`.nonempty()` is deprecated, it is recommended use `.min(1)` instead:
<img width="1087" alt="Screenshot 2024-01-15 at 19 43 17" src="https://github.com/Code-Forge-Net/remix-hook-form/assets/59517998/9d6853ac-5d50-4010-9bc9-b7fd878f6655">

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with latest version of zod: `3.22.4`

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules