### PR TITLE
docs: update readme and specify install of react-hook-form

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,16 @@ And the best part? Remix-hook-form has zero dependencies, making it easy to inte
 
 Oh, and did we mention that this is fully Progressively enhanced? That's right, you can use this with or without javascript!
 
-## Installation
 
-You can install the latest version of remix-hook-form using [npm](https://www.npmjs.com/):
+## Install
 
-`npm install remix-hook-form`
-
-Or, if you prefer [yarn](https://yarnpkg.com/):
-
-`yarn add remix-hook-form`
+    npm install remix-hook-form react-hook-form
 
 ## Basic usage
 
-Here is an example usage of remix-hook-form. It will work with **and without** JS.
+Here is an example usage of remix-hook-form. It will work with **and without** JS. Before running the example, ensure to install additional dependencies:
+
+    npm install zod @hookform/resolvers
 
 ```ts
 import { useRemixForm, getValidatedFormData } from "remix-hook-form";


### PR DESCRIPTION
# Description

Some small changes to the readme to remove friction, as I had some problems running the example. It was not obvious that react-hook-form should be installed (for me at least).

Also removed yarn, seems like remix itself only uses npm in their docs, also same for react-hook-form. Just a suggestion, feel free to have yarn as well :)

The commands also now are able to be copied with a mouse click.



## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors