### PR TITLE
fix: add passthrough options to reset

### DIFF
--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -15,6 +15,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import type {
   DefaultValues,
   FieldValues,
+  KeepStateOptions,
   Path,
   RegisterOptions,
   UseFormHandleSubmit,
@@ -97,9 +98,12 @@ export const useRemixForm = <T extends FieldValues>({
       submitHandlers?.onValid ?? onSubmit,
       submitHandlers?.onInvalid ?? onInvalid,
     ),
-    reset: (values?: T | DefaultValues<T> | undefined) => {
+    reset: (
+      values?: T | DefaultValues<T> | undefined,
+      options?: KeepStateOptions,
+    ) => {
       setIsSubmittedSuccessfully(false);
-      methods.reset(values);
+      methods.reset(values, options);
     },
     register: (
       name: Path<T>,


### PR DESCRIPTION
This aligns the interface of the `reset` method returned by `useRemixForm` with the method from `useForm`

# Description 

Expose the options that React Hook Form allows for the `reset` function to consumers of `useRemixForms`

Fixes #73

If this is a new feature please add a description of what was added and why below:

Allows user to specify [options](https://react-hook-form.com/docs/useform/reset) to reset method.

## Type of change

New feature (non-breaking change which adds functionality).

I did not edit the docs as `reset()` is not mentioned in them. Perhaps it should be though.

# How Has This Been Tested?

Used in my project. Options are typed correctly, and I saw the expected change in behavior from `keepErrors`, `keepValues`, and `keepDirty`.

Happy to elaborate more. I also skipped unit tests for now.

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- ~I have added tests that prove my fix is effective or that my feature works~
- ~New and existing unit tests pass locally with my changes~
- [x] Any dependent changes have been merged and published in downstream modules