### PR TITLE
Fix extra re-renders caused by formState changes

### DIFF
--- a/src/hook/index.test.tsx
+++ b/src/hook/index.test.tsx
@@ -134,6 +134,40 @@ describe("useRemixForm", () => {
       });
     });
   });
+
+  it("should not re-render on validation if isValidating is not being accessed", async () => {
+    const renderHookWithCount = () => {
+      let count = 0;
+      const renderCount = () => count;
+      const result = renderHook(() => {
+        count++;
+        return useRemixForm({
+          mode: "onChange",
+          resolver: () => ({
+            values: {
+              name: "",
+            },
+            errors: {},
+          }),
+        });
+      });
+      return { renderCount, ...result };
+    };
+
+    const { result, renderCount } = renderHookWithCount();
+
+    await act(async () => {
+      result.current.setValue("name", "John", { shouldValidate: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await act(async () => {
+      result.current.setValue("name", "Bob", { shouldValidate: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(renderCount()).toBe(1);
+  });
 });
 
 afterEach(cleanup);

--- a/src/hook/index.test.tsx
+++ b/src/hook/index.test.tsx
@@ -168,6 +168,44 @@ describe("useRemixForm", () => {
 
     expect(renderCount()).toBe(1);
   });
+
+  it("should re-render on validation if isValidating is being accessed", async () => {
+    const renderHookWithCount = () => {
+      let count = 0;
+      const renderCount = () => count;
+      const result = renderHook(() => {
+        count++;
+        return useRemixForm({
+          mode: "onChange",
+          resolver: () => ({
+            values: {
+              name: "",
+            },
+            errors: {},
+          }),
+        });
+      });
+      return { renderCount, ...result };
+    };
+
+    const { result, renderCount } = renderHookWithCount();
+
+    // Accessing isValidating
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const isValidating = result.current.formState.isValidating;
+
+    await act(async () => {
+      result.current.setValue("name", "John", { shouldValidate: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    await act(async () => {
+      result.current.setValue("name", "Bob", { shouldValidate: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(renderCount()).toBe(3);
+  });
 });
 
 afterEach(cleanup);

--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -78,6 +78,8 @@ export const useRemixForm = <T extends FieldValues>({
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const onInvalid = () => {};
 
+  // React-hook-form uses lazy property getters to avoid re-rendering when properties
+  // that aren't being used change. Using getters here preservers that lazy behavior.
   const formState: FormState<T> = {
     get isDirty() {
       return methods.formState.isDirty;

--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -15,6 +15,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import type {
   DefaultValues,
   FieldValues,
+  FormState,
   KeepStateOptions,
   Path,
   RegisterOptions,
@@ -77,21 +78,50 @@ export const useRemixForm = <T extends FieldValues>({
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const onInvalid = () => {};
 
-  const {
-    dirtyFields,
-    isDirty,
-    isSubmitSuccessful,
-    isSubmitted,
-    isSubmitting,
-    isValid,
-    isValidating,
-    validatingFields,
-    touchedFields,
-    submitCount,
-    errors,
-    isLoading,
-    disabled,
-  } = methods.formState;
+  const formState: FormState<T> = {
+    get isDirty() {
+      return methods.formState.isDirty;
+    },
+    get isLoading() {
+      return methods.formState.isLoading;
+    },
+    get isSubmitted() {
+      return methods.formState.isSubmitted;
+    },
+    get isSubmitSuccessful() {
+      return isSubmittedSuccessfully || methods.formState.isSubmitSuccessful;
+    },
+    get isSubmitting() {
+      return isSubmittingForm || methods.formState.isSubmitting;
+    },
+    get isValidating() {
+      return methods.formState.isValidating;
+    },
+    get isValid() {
+      return methods.formState.isValid;
+    },
+    get disabled() {
+      return methods.formState.disabled;
+    },
+    get submitCount() {
+      return methods.formState.submitCount;
+    },
+    get defaultValues() {
+      return methods.formState.defaultValues;
+    },
+    get dirtyFields() {
+      return methods.formState.dirtyFields;
+    },
+    get touchedFields() {
+      return methods.formState.touchedFields;
+    },
+    get validatingFields() {
+      return methods.formState.validatingFields;
+    },
+    get errors() {
+      return methods.formState.errors;
+    },
+  };
 
   return {
     ...methods,
@@ -117,21 +147,7 @@ export const useRemixForm = <T extends FieldValues>({
         defaultValue: data?.defaultValues?.[name] ?? "",
       }),
     }),
-    formState: {
-      disabled,
-      dirtyFields,
-      isDirty,
-      isSubmitSuccessful: isSubmittedSuccessfully || isSubmitSuccessful,
-      isSubmitted,
-      isSubmitting: isSubmittingForm || isSubmitting,
-      isValid,
-      isValidating,
-      validatingFields,
-      touchedFields,
-      submitCount,
-      isLoading,
-      errors,
-    },
+    formState,
   };
 };
 interface RemixFormProviderProps<T extends FieldValues>


### PR DESCRIPTION
# Description

Fixes extra full form re-renders that don't happen when using react-hook-form. Specifically, re-renders that happen because of formState changes, even when the user of the hook isn't watching formState values.

Below is a simple example showing that the entire form is being re-rendered on every key stroke into an input. This is happening because the validation mode is set to onChange and the formState.isValidating flag is changing on every key stroke (note that I haven't accessed formState.isValidating in the component, so the expected behavior is that the component does not re-render based on it).

```typescript
const {
  register,
  handleSubmit,
  formState: { errors },
} = useRemixForm<FormData>({
  resolver,
  mode: "onChange",
});
``` 

https://github.com/Code-Forge-Net/remix-hook-form/assets/5779535/5f53b399-c8a7-4029-9bee-36f099a3ccbc

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested by hand using the React Developer Tools in Chrome to observe re-renders.
- Added unit tests that track the number of re-renders when isValidating is being accessed vs. not.

After the changes:

https://github.com/Code-Forge-Net/remix-hook-form/assets/5779535/ed7035bb-145b-4b64-8285-d047d0c05cc4

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules