### PR TITLE
feat: support react-hook-form 7.75.0 (isReady + setValues) (#180)

### DIFF
--- a/.changeset/rhf-7-75-compat.md
+++ b/.changeset/rhf-7-75-compat.md
@@ -1,0 +1,5 @@
+---
+"remix-hook-form": minor
+---
+
+Fix type errors with react-hook-form 7.75.0. `FormState` gained an `isReady` field and `UseFormReturn` gained `setValues` in 7.75; the wrapped `formState` now exposes `isReady` (preserving the lazy getter behavior) and `setValues` flows through the hook's return type. Resolves the "Property 'setValues'/'isReady' is missing" errors (#180).

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.51.0",
+        "react-hook-form": "^7.75.0",
         "rollup": "^3.20.2",
         "rollup-plugin-typescript2": "^0.34.1",
         "tsup": "^8.3.5",
@@ -38,7 +38,7 @@
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0",
         "react-dom": "^18.2.0 || ^19.0.0",
-        "react-hook-form": "^7.55.0",
+        "react-hook-form": "^7.75.0",
         "react-router": ">=7.5.0"
       }
     },
@@ -9212,9 +9212,10 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.55.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
-      "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -12457,6 +12458,22 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "test-apps/react-router/node_modules/react-hook-form": {
+      "version": "7.55.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
+      "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "test-apps/react-router/node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "peerDependencies": {
     "react": "^18.2.0 || ^19.0.0",
     "react-dom": "^18.2.0 || ^19.0.0",
-    "react-hook-form": "^7.55.0",
+    "react-hook-form": "^7.75.0",
     "react-router": ">=7.5.0"
   },
   "readme": "https://github.com/code-forge-io/remix-hook-form#readme",
@@ -104,7 +104,7 @@
     "prettier": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-hook-form": "^7.51.0",
+    "react-hook-form": "^7.75.0",
     "rollup": "^3.20.2",
     "rollup-plugin-typescript2": "^0.34.1",
     "tsup": "^8.3.5",

--- a/src/hook/index.test.tsx
+++ b/src/hook/index.test.tsx
@@ -58,6 +58,7 @@ describe("useRemixForm", () => {
       submitCount: 0,
       isLoading: false,
       errors: {},
+      isReady: true,
     });
     expect(result.current.handleSubmit).toBeInstanceOf(Function);
   });
@@ -217,7 +218,10 @@ describe("useRemixForm", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(renderCount()).toBe(1);
+    // react-hook-form >= 7.75 emits an extra formState notification per
+    // validation cycle (two cycles here), so the baseline render count is 3.
+    // The optimization still holds: this stays below the subscribed case below.
+    expect(renderCount()).toBe(3);
   });
 
   it("should re-render on validation if isValidating is being accessed", async () => {
@@ -255,7 +259,10 @@ describe("useRemixForm", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
-    expect(renderCount()).toBe(3);
+    // Accessing isValidating subscribes to it, so each validation cycle
+    // re-renders — 2 more than the unsubscribed case above (3 -> 5 on
+    // react-hook-form >= 7.75, which raised the baseline by 2).
+    expect(renderCount()).toBe(5);
   });
 
   it("should not flash incorrect isSubmitting status", async () => {

--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -187,6 +187,9 @@ export const useRemixForm = <
       get errors() {
         return methods.formState.errors;
       },
+      get isReady() {
+        return methods.formState.isReady;
+      },
     }),
     [methods.formState, isSubmittedSuccessfully, isSubmittingNetwork],
   );


### PR DESCRIPTION
Fixes #180 — TS errors after upgrading `react-hook-form` to 7.75.0.

## Root cause
RHF 7.75.0 added two members, and `remix-hook-form` re-implements those interfaces:
- `FormState.isReady` — `useRemixForm` rebuilds `formState` with lazy getters (to preserve RHF's render optimization), so it was missing the new field → `Property 'isReady' is missing in type … FormState`.
- `UseFormReturn.setValues` — present at runtime via `...methods`, but the **published 7.1.1 types were built pre-7.75** and didn't include it → consumers on 7.75 saw `Property 'setValues' is missing`.

## Fix
- Expose `isReady` via a lazy getter that proxies `methods.formState.isReady` (same pattern as the other fields).
- `setValues` flows through the spread; building against 7.75 restores it in the generated `.d.ts` (verified: the return type now includes `setValues: UseFormSetValues<…>`).
- Bump `react-hook-form` to `^7.75.0` in **both `devDependencies` and `peerDependencies`** — the wrapper now targets 7.75's `FormState`/`UseFormReturn`.

## Tests
- `formState` snapshot test now includes `isReady`.
- Two render-count assertions updated: RHF 7.75 raised the baseline by 2 (one extra `formState` notification per validation cycle). Verified independently of this change — the failures reproduce on unmodified `main` once RHF is bumped to 7.75, so it's upstream behavior. The lazy-getter optimization still holds: unsubscribed `3` vs subscribed-to-`isValidating` `5`.

Typecheck ✓, all 48 tests ✓, build ✓ against `react-hook-form@7.75.0`.

## Release
Ships as a **minor** (changeset included). Once merged, the Release PR bumps **7.1.1 → 7.2.0** and publishes with provenance.

## Note (out of scope)
`npm run lint` is broken repo-wide — ESLint 9 is installed but there's no `eslint.config.js` (flat config). CI's `validate.yaml` only runs typecheck + vitest (the lint job is commented out), so this doesn't block, but it's worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
